### PR TITLE
Add option for generating entitlements using legacy syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 This version is compatible with [SimpleSAMLphp v1.14](https://simplesamlphp.org/docs/1.14/simplesamlphp-changelog)
 
 ### Added
@@ -21,7 +23,7 @@ This version is compatible with [SimpleSAMLphp v1.14](https://simplesamlphp.org/
 ### Changed
 - Moved placeholder variables to configuration
   - urnNamespace
-  - fqdn
+  - urnAuthority
   - COmanage registry redirect URLs
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ A SimpleSAMLphp module for retrieving attributes from [COmanage Registry](https:
 
 In a nuthshell, this module provides a set of SimpleSAMLphp authentication processing filters allowing to use COmanage Registry as an Attribute Authority. Specifically, the module supports retrieving the following user information from COmanage:
   * CO person profile information, including login identifiers
-  * CO group membership information, which is encapsulated in `eduPersonEntitlement` attribute values
+  * CO group membership information, which is encapsulated in `eduPersonEntitlement` attribute values following the [AARC-G002](https://aarc-community.org/guidelines/aarc-g002/) specification
 
 To this end, the above information can be retrieved through the COmanage Registry REST API. Support for directly querying the COmanage Registry DB is also foreseen.
 
@@ -66,6 +66,7 @@ The following authproc filter configuration options are supported:
   * `urnNamespace`: Required, a string to use as the URN namespace of the generated `eduPersonEntitlement` values containing group membership and role information.
   * `urnAuthority`: Required, a string to use as the authority of the generated `eduPersonEntitlement` URN values containing group membership and role information.
   * `registryUrls`: Required, an array of COmanage endpoints representing standard Enrollment Flow types. All the four endpoints are mandatory.
+  * `urnLegacy`: Optional, a boolean value for controlling whether to generate `eduPersonEntitlement` URN values using the legacy syntax. Defaults to `false`.
   
 Note: In case you need to change the format of the entitlements you need to modify the source code.
 

--- a/README.md
+++ b/README.md
@@ -61,10 +61,10 @@ The following authproc filter configuration options are supported:
   * `coUserIdType`: Optional, a string that indicates the type of the identifier that the users have. Defaults to `epuid`.
   * `userIdAttribute`: Optional, a string containing the name of the attribute whose value to use for querying the COmanage Registry. Defaults to `"eduPersonPrincipalName"`.
   * `blacklist`: Optional, an array of strings that contains the SPs that the module will skip to process.
-  * `voWhitelist`: Optional, an array of strings that contains roles (COUs) that the module will generate entitlements.
+  * `voWhitelist`: Optional, an array of strings that contains VOs (COUs) for which the module will generate entitlements.
   * `communityIdps`: Optional, an array of strings that contains the Entity Ids of trusted communities.
-  * `urnNamespace`: Required, A string to use as the URN namespace of the generated `eduPersonEntitlement` values containing CO group membership information. Defauls to `"urn:mace:example.org"`.
-  * `fqdn`: Required, A string to use as a Fully Qualified Domain Name in the the entitlements
+  * `urnNamespace`: Required, a string to use as the URN namespace of the generated `eduPersonEntitlement` values containing group membership and role information.
+  * `urnAuthority`: Required, a string to use as the authority of the generated `eduPersonEntitlement` URN values containing group membership and role information.
   * `registryUrls`: Required, an array of COmanage endpoints representing standard Enrollment Flow types. All the four endpoints are mandatory.
   
 Note: In case you need to change the format of the entitlements you need to modify the source code.
@@ -88,7 +88,7 @@ Note: In case you need to change the format of the entitlements you need to modi
                'https://example1.com/idp',
             ),
             'urnNamespace' => 'urn:mace:example.org',
-            'fqdn'         => 'example.eu',
+            'urnAuthority' => 'example.eu',
             'registryUrls' => array(
                'self_sign_up'      => 'https://example.com/registry/co_petitions/start/coef:1', // Required
                'sign_up'           => 'https://example.com/registry/co_petitions/start/coef:2', // Required

--- a/lib/Auth/Process/COmanageDbClient.php
+++ b/lib/Auth/Process/COmanageDbClient.php
@@ -60,6 +60,10 @@ class sspmod_attrauthcomanage_Auth_Process_COmanageDbClient extends SimpleSAML_A
     private $registryUrls = array();
     private $communityIdps = array();
 
+    // If true, this filter will also generate entitlements using the
+    // legacy URN format
+    private $urnLegacy = false;
+
     private $_basicInfoQuery = 'select'
         . ' person.id,'
         . ' person.status,'
@@ -284,6 +288,15 @@ class sspmod_attrauthcomanage_Auth_Process_COmanageDbClient extends SimpleSAML_A
             }
             $this->communityIdps = $config['communityIdps'];
         }
+
+        if (array_key_exists('urnLegacy', $config)) {
+            if (!is_bool($config['urnLegacy'])) {
+                SimpleSAML_Logger::error("[attrauthcomanage] Configuration error: 'urnLegacy' not a boolean");
+                throw new SimpleSAML_Error_Exception(
+                    "attrauthcomanage configuration error: 'urnLegacy' not a boolean");
+            }
+            $this->urnLegacy = $config['urnLegacy'];
+        }
     }
 
     public function process(&$state)
@@ -382,6 +395,15 @@ class sspmod_attrauthcomanage_Auth_Process_COmanageDbClient extends SimpleSAML_A
                         . urlencode($voName)         // VO
                         . ":role=".$role             // role
                         . "#" . $this->urnAuthority; // AA FQDN
+                    // Enable legacy URN syntax for compatibility reasons?
+                    if ($this->urnLegacy) {
+                        $state['Attributes']['eduPersonEntitlement'][] =
+                            $this->urnNamespace          // URN namespace
+                            . ':' . $this->urnAuthority; // AA FQDN
+                            . ':' . $role                // role
+                            . "@"                        // VO delimiter
+                            . urlencode($voName);        // VO
+                    }
                 }
             }
 
@@ -405,6 +427,15 @@ class sspmod_attrauthcomanage_Auth_Process_COmanageDbClient extends SimpleSAML_A
                         . urlencode($groupName)      // VO
                         . ":role=".$role             // role
                         . "#" . $this->urnAuthority; // AA FQDN
+                    // Enable legacy URN syntax for compatibility reasons?
+                    if ($this->urnLegacy) {
+                        $state['Attributes']['eduPersonEntitlement'][] =
+                            $this->urnNamespace          // URN namespace
+                            . ':' . $this->urnAuthority; // AA FQDN
+                            . ':' . $role                // role
+                            . "@"                        // VO delimiter
+                            . urlencode($voName);        // VO
+                    }
                 }
             }
         } catch (\Exception $e) {

--- a/lib/Auth/Process/COmanageDbClient.php
+++ b/lib/Auth/Process/COmanageDbClient.php
@@ -22,7 +22,7 @@
  *               'https://example1.com/idp',
  *            ),
  *            'urnNamespace' => 'urn:mace:example.eu',
- *            'fqdn'         => 'example.eu',
+ *            'urnAuthority'         => 'example.eu',
  *            'registryUrls' => array(
  *               'self_sign_up'      => 'https://example.com/registry/co_petitions/start/coef:1',
  *               'sign_up'           => 'https://example.com/registry/co_petitions/start/coef:2',
@@ -56,7 +56,7 @@ class sspmod_attrauthcomanage_Auth_Process_COmanageDbClient extends SimpleSAML_A
     private $voWhitelist = array();
 
     private $urnNamespace = null;
-    private $fqdn = null;
+    private $urnAuthority = null;
     private $registryUrls = array();
     private $communityIdps = array();
 
@@ -212,13 +212,13 @@ class sspmod_attrauthcomanage_Auth_Process_COmanageDbClient extends SimpleSAML_A
         }
         $this->urnNamespace = $config['urnNamespace'];
 
-        // fqdn config
-        if (!array_key_exists('fqdn', $config) && !is_string($config['fqdn'])) {
-          SimpleSAML_Logger::error("[attrauthcomanage] Configuration error: 'fqdn' not specified or wrong format(string required)");
+        // urnAuthority config
+        if (!array_key_exists('urnAuthority', $config) && !is_string($config['urnAuthority'])) {
+          SimpleSAML_Logger::error("[attrauthcomanage] Configuration error: 'urnAuthority' not specified or wrong format(string required)");
           throw new SimpleSAML_Error_Exception(
-            "attrauthcomanage configuration error: 'fqdn' not specified");
+            "attrauthcomanage configuration error: 'urnAuthority' not specified");
         }
-        $this->fqdn = $config['fqdn'];
+        $this->urnAuthority = $config['urnAuthority'];
 
         // Redirect Urls config
         if (!array_key_exists('registryUrls', $config)) {
@@ -377,11 +377,11 @@ class sspmod_attrauthcomanage_Auth_Process_COmanageDbClient extends SimpleSAML_A
                 }
                 foreach ($roles as $role) {
                     $state['Attributes']['eduPersonEntitlement'][] =
-                        $this->urnNamespace        // create $urn_namespace
-                        . ":group:"                // URN namespace
-                        . urlencode($voName)       // VO
-                        . ":role=".$role           // role
-                        . "#" . $this->fqdn;       // AA FQDN, create $fqdn
+                        $this->urnNamespace          // URN namespace
+                        . ":group:"                  // group literal
+                        . urlencode($voName)         // VO
+                        . ":role=".$role             // role
+                        . "#" . $this->urnAuthority; // AA FQDN
                 }
             }
 
@@ -400,11 +400,11 @@ class sspmod_attrauthcomanage_Auth_Process_COmanageDbClient extends SimpleSAML_A
                 }
                 foreach ($roles as $role) {
                     $state['Attributes']['eduPersonEntitlement'][] =
-                        $this->urnNamespace       // URN namespace
-                        . ":group:registry:"      // URN namespace
-                        . urlencode($groupName)   // VO
-                        . ":role=".$role          // role
-                        . "#" . $this->fqdn;      // AA FQDN
+                        $this->urnNamespace          // URN namespace
+                        . ":group:registry:"         // URN namespace
+                        . urlencode($groupName)      // VO
+                        . ":role=".$role             // role
+                        . "#" . $this->urnAuthority; // AA FQDN
                 }
             }
         } catch (\Exception $e) {


### PR DESCRIPTION
*  introduce `urnLegacy` param to control whether to generate entitlement values using the legacy syntax
* rename `fqdn` parameter as `urnAuthority`
* improve docs