### PR TITLE
BUG_include_scoped_affiliation_only_once_in_session

### DIFF
--- a/lib/Auth/Process/COmanageDbClient.php
+++ b/lib/Auth/Process/COmanageDbClient.php
@@ -504,6 +504,8 @@ class sspmod_attrauthcomanage_Auth_Process_COmanageDbClient extends SimpleSAML_A
                   ',',
                   $attributes['edupersonscopedaffiliation']
                 );
+                // XXX Remove any duplicate edupersonscopedaffiliation
+                $state['Attributes']['eduPersonScopedAffiliation'] = array_filter(array_unique($state['Attributes']['eduPersonScopedAffiliation']));
             }
             if (!empty($attributes['identifier'])) {
                 $state['Attributes']['uid'] = array($attributes['identifier']);


### PR DESCRIPTION
Include edupersonScopedAffiliation only once in SSP session if multiple Identity Providers provide the same