### PR TITLE
New configuration option for generating entitlements without role attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+# Added
+
+- New configuration option for generating entitlements without role attribute
+
 ## [v2.5.0] - 2022-05-16
 
 # Added

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ The following authproc filter configuration options are supported:
     * `communityIdps`: An array of strings that contains the Entity Ids of trusted communities. Defaults to `array()`.
     * `communityIdpTags`: An array of strings that contains tags, indicating that every Idp having at least one of them is considered as community. Defaults to `array('community')`.
     * `urnLegacy`: A boolean value for controlling whether to generate `eduPersonEntitlement` URN values using the legacy syntax. Defaults to `false`.
+    * `noRoleEntitlements`: A boolean value for controlling whether to generate `eduPersonEntitlement` URN values without role attribute. Defaults to `false`.
     * `certificate`: A boolean value for controlling whether to fetch `Certificates` from User's Profile. Defaults to `false`.
     * `retrieveSshKeys`: A boolean value for controlling whether to retrieve SSH keys from User's Profile. Defaults to `false`.
     * `mergeEntitlements`: A boolean to indicate whether the redundant `eduPersonEntitlement` will be removed from the state. Defaults to `false`.

--- a/lib/Auth/Process/COmanageDbClient.php
+++ b/lib/Auth/Process/COmanageDbClient.php
@@ -38,6 +38,7 @@
  *            'urnAuthority' => 'example.eu',
  *            'retrieveAUP' => true,
  *            'mergeEntitlements' => false,
+ *            'noRoleEntitlements' => false,
  *            'certificate' => false,
  *            'retrieveSshKeys' => true,
  *            'registryUrls' => [
@@ -109,6 +110,8 @@ class COmanageDbClient extends \SimpleSAML\Auth\ProcessingFilter
     // If true, this filter will also generate entitlements using the
     // legacy URN format
     private $urnLegacy = false;
+    // If true, this filter will also generate entitlements without the role attribute
+    private $noRoleEntitlements = false;
     private $voRoles = [];
     private $voRolesDef = [];
     private $coGroupMemberships = [];
@@ -850,7 +853,15 @@ class COmanageDbClient extends \SimpleSAML\Auth\ProcessingFilter
                   . $group . ':' . $role       // role
                   . "@"                        // VO delimiter
                   . urlencode($vo_name);       // VO
-          } // Depricated syntax
+        } // Deprecated syntax
+
+        if ($this->noRoleEntitlements) {
+            $state['Attributes']['eduPersonEntitlement'][] = 
+                  $this->urnNamespace // URN namespace
+                  . ':' . 'group:' 
+                  . urlencode($vo_name) // VO
+                  . '#'. $this->urnAuthority; 
+        }
       }
     }
 
@@ -1742,6 +1753,7 @@ class COmanageDbClient extends \SimpleSAML\Auth\ProcessingFilter
                 'coUserIdType' => 'is_string',
                 'userIdAttribute' => 'is_string',
                 'urnLegacy' => 'is_bool',
+                'noRoleEntitlements' => 'is_bool',
                 'certificate' => 'is_bool',
                 'mergeEntitlements' => 'is_bool',
                 'coTermsId' => 'is_int',


### PR DESCRIPTION
As long as we don't use legacy format anymore, we can use it for OpenAIRE.